### PR TITLE
Implement Home Assistant MQTT Discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+.idea
+*.swp


### PR DESCRIPTION
HA будет сам обнаруживать терминал и его элементы, кроме отправки текстовых сообщений с HA на терминал.
Say теперь сенсор содержащий текст:
```yaml
alias: stt_tts
description: ''
trigger:
  - platform: state
    entity_id: sensor.say
condition: []
action:
  - service: script.turn_on
    target:
      entity_id: script.1632945073604
    data:
      variables:
        message: '{{ states(''sensor.say'') }}'
mode: single
```
Можно настраивать громкости, и реагировать на то что терминал говорит\слушает.
Можно добавить больше датчиков, просто забив их все (можно и автоматизировать, но думаю смысла нет, их не так уж и много).

Еще надо переписать ридми.