### PR TITLE
Some improvements

### DIFF
--- a/main.py
+++ b/main.py
@@ -63,7 +63,7 @@ class Main:
             'topic': self.TOPIC + '/availability',
         }
         # Для генерации uniq_id
-        self._sensors_order = ['binary_sensor', 'sensor', 'number', 'switch']
+        self._sensors_order = ['binary_sensor', 'sensor', 'number', 'switch', 'text']
         self._sensors = {
             'binary_sensor': [
                 {'name': 'record',
@@ -104,6 +104,12 @@ class Main:
                  'icon': 'hass:microphone-settings',
                  'pl_on': 'on',
                  'pl_off': 'off'
+                 },
+            ],
+            'text': [
+                {'name': 'Say',
+                 'cmd_t': self.TOPIC_CMD,
+                 'cmd_tpl': '{"tts": {{ value|tojson }} }'
                  },
             ],
         }

--- a/main.py
+++ b/main.py
@@ -166,12 +166,13 @@ class Main:
         for topic in self._controllable_ctl_topics:
             self._mqtt.subscribe(topic)
         self._mqtt.subscribe(self._ha_status_topic)
-        self._send_initial_data()
+        self.own.messenger(self._send_initial_data, None)
 
     def _send_initial_data(self):
         self._send_discovery()
+        time.sleep(3.0)
         self._send_availability(online=True)
-        self.own.messenger(self._send_default_values, None)
+        self._send_default_values()
 
     def _on_disconnect(self, client, userdata, rc):
         if not rc:
@@ -191,7 +192,8 @@ class Main:
                 status = message.payload.decode("utf-8")
                 self.log('Home Assistant: {}'.format(status))
                 if status == 'online':
-                    self._send_initial_data()
+                    time.sleep(5.0)
+                    self.own.messenger(self._send_initial_data, None)
             else:
                 msg = json.loads(message.payload.decode("utf-8"), strict=False)
         except Exception as e:


### PR DESCRIPTION
Исправил возможные потери терминала при рестарте ХА.

Добавил отправку say через [MQTT Text](https://www.home-assistant.io/integrations/text.mqtt/). Теперь не нужно писать скрипт для отправки say и создавать хелпера для ручного ввода, встроенное поле и для ввода и для скриптов. Работает начиная с Home Assistant 2022.12
![image](https://user-images.githubusercontent.com/42580940/206499076-3a4702e4-81b0-4995-8d95-11988621d9ef.png)
